### PR TITLE
hotfix: 크롤링 시 발생하는 에러 

### DIFF
--- a/src/main/java/com/cnubot/cnubotserver/foodcourt/service/crawling/FoodCrawling.java
+++ b/src/main/java/com/cnubot/cnubotserver/foodcourt/service/crawling/FoodCrawling.java
@@ -5,11 +5,13 @@ import com.cnubot.cnubotserver.foodcourt.enums.FoodCourt;
 import com.cnubot.cnubotserver.foodcourt.enums.Time;
 import com.cnubot.cnubotserver.foodcourt.enums.Week;
 import com.cnubot.cnubotserver.foodcourt.repository.MenuRepository;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
 import lombok.AllArgsConstructor;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
@@ -110,32 +112,54 @@ public class FoodCrawling {
         Optional<Week> findDay = Arrays.stream(Week.values()).filter(s -> s.getDay().equals(day)).findFirst();
 
         List<String> list = new ArrayList<>(Arrays.asList(target.split(" ")));
-        Optional<String> element = list.stream().filter(s -> s.contains("메인C")).findFirst();
-        String typeOfA = list.get(0);
-        List<String> listOfMainA = list;
-        if (element.isPresent()) {
-            int indexOfMainC = list.indexOf(element.get());
-            String typeOfC = list.get(indexOfMainC);
-            listOfMainA = list.subList(1, indexOfMainC);
-            List<String> listOfMainC = list.subList(indexOfMainC + 1, list.size());
-            Menu menuC = Menu.builder()
+        Long menuCount = list.stream().filter(s -> s.contains("메인")).count();
+
+        if (menuCount == 1) {
+            List<String> menus = list.subList(1, list.size());
+            Menu menu = Menu.builder()
                     .time(time)
-                    .foods(listOfMainC)
+                    .foods(menus)
                     .foodCourt(FoodCourt.DORMITORY)
-                    .type(typeOfC)
+                    .type(list.get(0))
                     .day(findDay.get())
                     .build();
-            repository.save(menuC);
+            repository.save(menu);
         }
-        Menu menuA = Menu.builder()
-                .time(time)
-                .foods(listOfMainA)
-                .foodCourt(FoodCourt.DORMITORY)
-                .type(typeOfA)
-                .day(findDay.get())
-                .build();
-        repository.save(menuA);
+        if (menuCount == 2) {
+            Optional<String> elementA = list.stream().filter(s -> s.contains("메인A")).findFirst();
+            Optional<String> elementC = list.stream().filter(s -> s.contains("메인C")).findFirst();
+            int indexOfA = list.indexOf(elementA.get());
+            int indexOfC = list.indexOf(elementC.get());
 
+            List<String> aMenus = null;
+            List<String> cMenus = null;
+            if (indexOfA < indexOfC) {
+                aMenus = list.subList(indexOfA + 1, indexOfC);
+                cMenus = list.subList(indexOfC + 1, list.size());
+            }
+            if (indexOfC < indexOfA) {
+                cMenus = list.subList(indexOfC + 1, indexOfC);
+                aMenus = list.subList(indexOfA + 1, list.size());
+            }
+
+            Menu aMenu = Menu.builder()
+                    .time(time)
+                    .foods(aMenus)
+                    .foodCourt(FoodCourt.DORMITORY)
+                    .type(list.get(indexOfA))
+                    .day(findDay.get())
+                    .build();
+
+            Menu cMenu = Menu.builder()
+                    .time(time)
+                    .foods(cMenus)
+                    .foodCourt(FoodCourt.DORMITORY)
+                    .type(list.get(indexOfC))
+                    .day(findDay.get())
+                    .build();
+            repository.save(aMenu);
+            repository.save(cMenu);
+        }
     }
 
     private String removeEng(String data) {

--- a/src/main/java/com/cnubot/cnubotserver/foodcourt/service/crawling/FoodCrawling.java
+++ b/src/main/java/com/cnubot/cnubotserver/foodcourt/service/crawling/FoodCrawling.java
@@ -1,5 +1,6 @@
 package com.cnubot.cnubotserver.foodcourt.service.crawling;
 
+import com.cnubot.cnubotserver.exception.CnuBotException;
 import com.cnubot.cnubotserver.foodcourt.entity.Menu;
 import com.cnubot.cnubotserver.foodcourt.enums.FoodCourt;
 import com.cnubot.cnubotserver.foodcourt.enums.Time;
@@ -101,13 +102,18 @@ public class FoodCrawling {
             String lunch = removeEng(tds.get(i + 2).select(".left").text()); // 점심
             String dinner = removeEng(tds.get(i + 3).select(".left").text()); // 저녁
             String day = getDay(tds.get(i).text());
-            dormitorySave(breakfast, day, Time.BREAKFAST);
-            dormitorySave(lunch, day, Time.LUNCH);
-            dormitorySave(dinner, day, Time.DINNER);
+            try {
+                dormitorySave(breakfast, day, Time.BREAKFAST);
+                dormitorySave(lunch, day, Time.LUNCH);
+                dormitorySave(dinner, day, Time.DINNER);
+            } catch (CnuBotException exception) {
+                // 추후 에러로그 따로 저장해 추가할 생각
+            }
+
         }
     }
 
-    private void dormitorySave(String target, String day, Time time) {
+    private void dormitorySave(String target, String day, Time time) throws CnuBotException {
         System.out.println(day);
         Optional<Week> findDay = Arrays.stream(Week.values()).filter(s -> s.getDay().equals(day)).findFirst();
 

--- a/src/test/java/com/cnubot/cnubotserver/foodcourt/service/crawling/FoodCrawlingTest.java
+++ b/src/test/java/com/cnubot/cnubotserver/foodcourt/service/crawling/FoodCrawlingTest.java
@@ -2,22 +2,25 @@ package com.cnubot.cnubotserver.foodcourt.service.crawling;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.cnubot.cnubotserver.exception.CnuBotException;
+import com.cnubot.cnubotserver.exception.Constants;
 import com.cnubot.cnubotserver.foodcourt.entity.Menu;
 import com.cnubot.cnubotserver.foodcourt.enums.FoodCourt;
 import com.cnubot.cnubotserver.foodcourt.enums.Time;
 import com.cnubot.cnubotserver.foodcourt.enums.Week;
+
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 import javax.swing.plaf.synth.SynthDesktopIconUI;
+
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 
 class FoodCrawlingTest {
@@ -42,41 +45,63 @@ class FoodCrawlingTest {
 
     }
 
-    private void save(String target, String day, Time time) {
+    private void save(String target, String day, Time time) throws Exception {
         System.out.println(day);
         Optional<Week> findDay = Arrays.stream(Week.values()).filter(s -> s.getDay().equals(day)).findFirst();
 
         List<String> list = new ArrayList<>(Arrays.asList(target.split(" ")));
-        Optional<String> element = list.stream().filter(s -> s.contains("메인C")).findFirst();
-        String typeOfA = list.get(0);
-        List<String> listOfMainA = list;
-        if (element.isPresent()) {
-            int indexOfMainC = list.indexOf(element.get());
-            String typeOfC = list.get(indexOfMainC);
-            listOfMainA = list.subList(1, indexOfMainC);
-            List<String> listOfMainC = list.subList(indexOfMainC + 1, list.size());
-            Menu menuC = Menu.builder()
+        Long menuCount = list.stream().filter(s -> s.contains("메인")).count();
+
+        if (menuCount == 1) {
+            List<String> menus = list.subList(1, list.size());
+            Menu menu = Menu.builder()
                     .time(time)
-                    .foods(listOfMainC)
+                    .foods(menus)
                     .foodCourt(FoodCourt.DORMITORY)
-                    .type(typeOfC)
+                    .type(list.get(0))
                     .day(findDay.get())
                     .build();
-            System.out.println(menuC);
+            System.out.println(menu);
         }
-        Menu menuA = Menu.builder()
-                .time(time)
-                .foods(listOfMainA)
-                .foodCourt(FoodCourt.DORMITORY)
-                .type(typeOfA)
-                .day(findDay.get())
-                .build();
-        System.out.println(menuA);
+        if (menuCount == 2) {
+            Optional<String> elementA = list.stream().filter(s -> s.contains("메인A")).findFirst();
+            Optional<String> elementC = list.stream().filter(s -> s.contains("메인C")).findFirst();
+            int indexOfA = list.indexOf(elementA.get());
+            int indexOfC = list.indexOf(elementC.get());
 
+            List<String> aMenus = null;
+            List<String> cMenus = null;
+            if (indexOfA < indexOfC) {
+                aMenus = list.subList(indexOfA + 1, indexOfC);
+                cMenus = list.subList(indexOfC + 1, list.size());
+            }
+            if (indexOfC < indexOfA) {
+                cMenus = list.subList(indexOfC + 1, indexOfC);
+                aMenus = list.subList(indexOfA + 1, list.size());
+            }
+
+            Menu aMenu = Menu.builder()
+                    .time(time)
+                    .foods(aMenus)
+                    .foodCourt(FoodCourt.DORMITORY)
+                    .type(list.get(indexOfA))
+                    .day(findDay.get())
+                    .build();
+            System.out.println(aMenu);
+
+            Menu cMenu = Menu.builder()
+                    .time(time)
+                    .foods(cMenus)
+                    .foodCourt(FoodCourt.DORMITORY)
+                    .type(list.get(indexOfC))
+                    .day(findDay.get())
+                    .build();
+            System.out.println(cMenu);
+        }
     }
 
     @Test
-    void 긱사_테스트() {
+    void 긱사_테스트() throws CnuBotException {
         Document document = getDoc(FoodCourt.DORMITORY.getPort());
         Elements tds = document.select(".diet_table").select("tbody").select("td");
 
@@ -85,9 +110,14 @@ class FoodCrawlingTest {
             String lunch = removeEng(tds.get(i + 2).select(".left").text()); // 점심
             String dinner = removeEng(tds.get(i + 3).select(".left").text()); // 저녁
             String day = getDay(tds.get(i).text());
-            save(breakfast, day, Time.BREAKFAST);
-            save(lunch, day, Time.LUNCH);
-            save(dinner, day, Time.DINNER);
+            try {
+                save(breakfast, day, Time.BREAKFAST);
+                save(lunch, day, Time.LUNCH);
+                save(dinner, day, Time.DINNER);
+            } catch (Exception e) {
+                throw new CnuBotException(Constants.ExceptionClass.FOOD_COURT, HttpStatus.NOT_FOUND, "학식 정보를 불러오는 중에 문제가 발생하였습니다.");
+            }
+
         }
     }
 


### PR DESCRIPTION
# Describe your changes

크롤링 부분에서 예상치 못한 메뉴 구성이 나와 에러가 생겼습니다. 
항상 Main A 타입의 메뉴만 상단에 먼저 나와 그에 맞춰 코드를 구성했지만 
![image](https://user-images.githubusercontent.com/86772586/207541029-735d7b08-2514-439b-936c-2a8a3489bf34.png)
위와 같이 MainC의 메뉴가 먼저 오는 경우에 대해 여러 조건으로 
- Main A와 Main C 둘 중 하나만 있을때 
- 둘 다 있다면 MainA와 MainC의 위치에 따라 메뉴 정보 저장

### Exception처리에 관하여
크롤링 같은 경우에는 User의 요청으로 반환되는것이 아닌 스프링 프로젝트 내에서 자체 문제입니다. 다음 PR까지 모든 상황에 대해서 Exception처리를 할 생각입니다 크롤링 데이터는 일관적이지 않다 보니 정확한 무슨 문제인지 직접 확인하지 않는 이상 알기 어렵습니다 그래서 자주 있을 수 있는 이 상황에서 발생한 error log들을 관리자 페이지에서 볼 수 있으면 좋겠습니다. 어떻게 생각하시나요?   

## Issue ticket number and link (optional)
#28 

## Checklist

- [x] 🤔 이 프로젝트의 스타일 가이드를 따르나요?
- [x] 🤔 머지하기 전에 스스로 코드에 문제가 없음을 확인했나요?
- [x] 🤔 필요한 주석을 필요한 곳에 넣어주었나요?

## Next Step Todo (optional)

## Questions

- 💬 질문 사항이에요!
- 🤷‍♂️ 확인 받고 싶은 부분이에요!
- 🔥 이건 꼭 확인해주세요!
